### PR TITLE
CompatibilityValidator: Patch email address path expression incorrect.

### DIFF
--- a/CompatibilityValidator/CompatibilityValidator/Program.cs
+++ b/CompatibilityValidator/CompatibilityValidator/Program.cs
@@ -44,7 +44,7 @@ namespace Tools
             "]." +
             AttributeNames.PostalCode;
 
-        // emails[type eq "Work" and Primary eq true]
+        // emails[type eq "Work" and Primary eq true].value
         public const string PathExpressionPrimaryWorkElectronicMailAddress =
             AttributeNames.ElectronicMailAddresses +
             "[" + AttributeNames.Type +
@@ -52,7 +52,7 @@ namespace Tools
             ElectronicMailAddress.Work +
             "\" and " +
             AttributeNames.Primary +
-            " eq true]";
+            " eq true].value";
 
         private static readonly Lazy<JavaScriptSerializer> Serializer =
             new Lazy<JavaScriptSerializer>(


### PR DESCRIPTION
No `Path.ValuePath` is specified so the update to the primary work email address doesn't actually do anything.